### PR TITLE
Add Open Uri Initializer

### DIFF
--- a/template.rb
+++ b/template.rb
@@ -241,6 +241,11 @@ after_bundle do
     end
   end
 
+  initializer 'open_uri.rb', <<-CODE
+    require "open-uri"
+
+  CODE
+
   # Set up dotenv
   file ".env.development", render_file(".env.development")
 


### PR DESCRIPTION
According to the new additions to the [project checklist](https://firstdraft.gitbook.io/teacher-s-manual/updating-old-projects-checklist), this branch adds:
* open_uri initializer similar to [this one](https://github.com/appdev-projects/omnicalc-actions/blob/master/config/initializers/open_uri.rb)