### PR TITLE
Render local file if path_to_file method fails

### DIFF
--- a/template.rb
+++ b/template.rb
@@ -25,7 +25,8 @@ def render_file(filename)
     begin
       open(path_to_file(filename)).read
     rescue
-      open(path_to_blob(filename)).read
+      file = File.join(File.expand_path(File.dirname(__FILE__)), "files", filename)
+      open(file).read
     end
   else
     IO.read(path_to_file(filename))


### PR DESCRIPTION
The template sets `ENV = :prod` which forces the `render_file` method to open files, like initializers, from the master branch. If the file doesn't exist on master, `open-uri` will throw an error and stop the generation.

![image](https://user-images.githubusercontent.com/17581658/58131900-7e684280-7be5-11e9-99de-d4ff972b9d3a.png)

I've changed a conditional to read from a local version of the file if the read from the master branch fails.