### PR TITLE
Add Alias for `ActiveRecord::AtributeMethods#[]` to `fetch` and `store`

### DIFF
--- a/files/attribute-methods-patch.rb
+++ b/files/attribute-methods-patch.rb
@@ -1,0 +1,6 @@
+module ActiveRecord
+  module AttributeMethods
+    alias fetch []
+    alias store []=
+  end
+end

--- a/template.rb
+++ b/template.rb
@@ -234,6 +234,8 @@ after_bundle do
 
 
   file "config/initializers/fetch_store_patch.rb", render_file("fetch_store_patch.rb")
+  file "config/initializers/attribute-methods-patch.rb", render_file("attribute-methods-patch.rb")
+
 
   inside "config" do
     inside "initializers" do


### PR DESCRIPTION
In response to this issue: [#102](https://github.com/firstdraft/appdev/issues/102)

Alias the `:[]` attribute method for `ActiveRecord` with `:fetch`.