### PR TITLE
Add dummy_spec.rb

### DIFF
--- a/files/dummy_spec.rb
+++ b/files/dummy_spec.rb
@@ -1,0 +1,7 @@
+require "rails_helper"
+
+describe "This project" do
+  it "is not graded" do
+    expect(1).to eq(1)
+  end
+end

--- a/template.rb
+++ b/template.rb
@@ -319,6 +319,9 @@ after_bundle do
   remove_file ".rspec"
   file ".rspec", render_file(".rspec")
 
+  empty_directory File.join("spec", "features")
+  file "spec/features/dummy_spec.rb", render_file("dummy_spec.rb")
+
   inside "spec" do
     insert_into_file "rails_helper.rb",
       after: "require 'rspec/rails'\n" do


### PR DESCRIPTION
In response to #41 and [#28](https://github.com/firstdraft/grade_runner/issues/28) 

The template files now creates a file, `spec/features/dummy_spec.rb` by default when run.