### PR TITLE
Add :fetch, :store methods for session & cookies hash

### DIFF
--- a/files/fetch_store_patch.rb
+++ b/files/fetch_store_patch.rb
@@ -1,0 +1,15 @@
+module ActionDispatch
+  class Request
+    class Session
+      alias_method :fetch, :[]
+      alias_method :store, :[]=
+    end
+  end
+  
+  class Cookies
+    class CookieJar
+      alias_method :fetch, :[]
+      alias_method :store, :[]=
+    end
+  end
+end

--- a/template.rb
+++ b/template.rb
@@ -231,6 +231,9 @@ after_bundle do
 
   file "config/initializers/nicer_errors.rb", render_file("nicer_errors.rb")
 
+
+  file "config/initializers/fetch_store_patch.rb", render_file("fetch_store_patch.rb")
+
   inside "config" do
     inside "initializers" do
       append_file "backtrace_silencers.rb" do


### PR DESCRIPTION
Relating to this issue [#80](https://github.com/firstdraft/appdev/issues/80)

Adds initializer that makes `:fetch` and `:store` alias methods for `:[]` and `:[]=` for the `session` and `cookies` Hashes.