### PR TITLE
Override ActiveRecord Relation to_s

### DIFF
--- a/files/active_record_relation_patch.rb
+++ b/files/active_record_relation_patch.rb
@@ -1,0 +1,7 @@
+module ActiveRecord
+  class Relation
+    def to_s
+      "Array of #{count} #{model}"
+    end
+  end
+end

--- a/template.rb
+++ b/template.rb
@@ -228,6 +228,7 @@ after_bundle do
   gsub_file "app/assets/javascripts/application.js", "//= require_tree .\n", ""
 
   # Better backtraces
+  file "config/initializers/active_record_relation_patch.rb", render_file("active_record_relation_patch.rb")
 
   file "config/initializers/nicer_errors.rb", render_file("nicer_errors.rb")
 


### PR DESCRIPTION
Regards to this issue [#104](https://github.com/firstdraft/appdev/issues/104)

Currently does this in the view templates

```
<p>
  Launch.where(id: 1)
<br/>
  <%= Launch.where(id: 1) %>
</p>
<p>
  Launch.all:
 <br/>
  <%= Launch.all %>
</p>
```


![image](https://user-images.githubusercontent.com/17581658/58284050-68868900-7d6f-11e9-9aef-6f8ec7755132.png)

