### PR TITLE
Disable generator JS, Helpers, & Styles

### DIFF
--- a/template.rb
+++ b/template.rb
@@ -118,6 +118,9 @@ after_bundle do
             g.test_framework nil
             g.factory_bot false
             g.scaffold_stylesheet false
+            g.stylesheets     false
+            g.javascripts     false
+            g.helper          false
           end
     RB
 


### PR DESCRIPTION
Addressing #48 

This branch modifies `application.rb` to prevent stylesheets, javascripts, and helpers from being generated with a `rails generate` command.

![generatorjunkpr](https://user-images.githubusercontent.com/17581658/59634119-a929b600-9113-11e9-99d4-f384621dbb67.PNG)
