### PR TITLE
Update template for Codio

### DIFF
--- a/files/.codio
+++ b/files/.codio
@@ -1,0 +1,19 @@
+{
+// Configure your Run and Preview buttons here.
+
+// Run button configuration
+  "commands": {
+        "Initial project setup (bin/setup)": "bin/setup",
+        "Start web server (rails server)": "rails server -b 0.0.0.0",
+        "Run database migrations (rails db:migrate)": "rails db:migrate",
+        "Hydrate with dummy data (rails dev:prime)": "rails dev:prime"
+  },
+
+// Preview button configuration
+  "preview": {
+        "Live app": "http://{{domain3000}}/",
+        "Git client": "http://{{domain3000}}/git",
+        "ActiveAdmin": "http://{{domain3000}}/admin",
+        "Current File (static)": "http://{{domain}}/{{filepath}}"     
+  }
+}

--- a/files/dev.rake
+++ b/files/dev.rake
@@ -1,5 +1,5 @@
-namespace :dev do
+namespace(:dev) do
   desc "Hydrate the database with some dummy data to look at so that developing is easier"
-  task :prime do
+  task({ :prime => :environment}) do
   end
 end

--- a/files/setup
+++ b/files/setup
@@ -14,19 +14,6 @@ chdir APP_ROOT do
   # This script is a starting point to setup your application.
   # Add necessary setup steps to this file.
 
-  runs = 0
-  runs_path = ".setup_runs"
-  if !File.exist?(runs_path)
-    system! "touch " + runs_path
-    system! "echo '0' > " + runs_path
-    runs = open(runs_path).read.to_i
-  else
-    runs = open(runs_path).read.to_i
-    cmd = "echo '#{runs + 1}' > " + runs_path
-    system! cmd
-    runs = open(runs_path).read.to_i
-  end
-
   puts "== Installing dependencies =="
   system! "bundle install"
 
@@ -43,18 +30,8 @@ chdir APP_ROOT do
   system! "rails db:create"
   system! "rails db:migrate"
   system! "rails db:seed"
-  # system! "bin/rails dev:prime"
 
   # This script is a starting point to setup your application.
   # Add necessary setup steps to this file.
-
-
-  puts "\n== Installing web_git dependencies =="
-  system! "npm install diff2html-cli"
-
-  puts "\n== Installing Cloud9 plugins  =="
-  system! "curl --remote-name https://raw.githubusercontent.com/firstdraft/cloud9-setup/master/cloud9_plugins.sh"
-  system! "sh cloud9_plugins.sh"
-
 
 end

--- a/template.rb
+++ b/template.rb
@@ -45,6 +45,7 @@ gsub_file "Gemfile", /^gem\s+["']sqlite3["'].*$/,''
 # Add standard gems
 # =================
 
+gem "hashdiff", [">= 1.0.0.beta1", "< 2.0.0"]
 
 gem_group :development, :test do
   gem "awesome_print"
@@ -54,14 +55,13 @@ gem_group :development, :test do
   gem "pry-rails"
   gem "sqlite3", "~> 1.3.6"
   gem "table_print"
-  gem "web_git", github: "firstdraft/web_git"
+  gem "web_git"
 end
 
 gem_group :development do
   gem "annotate"
   gem "better_errors"
   gem "binding_of_caller"
-  gem "dev_toolbar", github: "firstdraft/dev_toolbar"
   gem "draft_generators", github: "firstdraft/draft_generators"
   gem "letter_opener"
   gem "meta_request"
@@ -127,6 +127,7 @@ after_bundle do
             g.helper          false
           end
           config.action_controller.default_protect_from_forgery = false
+          config.active_record.belongs_to_required_by_default = false
           RUBY
       end
   end
@@ -156,20 +157,6 @@ after_bundle do
     MD
   end
 
-  # Add dev toolbar to application layout
-
-  inside "app" do
-    inside "views" do
-      inside "layouts" do
-        insert_into_file "application.html.erb", before: "  </body>" do
-          <<-RB.gsub(/^        /, "")
-
-            <%= dev_tools if Rails.env.development? %>
-          RB
-        end
-      end
-    end
-  end
 
   inside "config" do
     inside "environments" do
@@ -192,6 +179,10 @@ after_bundle do
       end
     end
   end
+
+  gsub_file "config/environments/development.rb",
+    "config.assets.debug = true",
+    "config.assets.debug = false"
 
   # TODO: Add a prompt about whether to include BS and/or FA
   # TODO: Update for BS4 beta
@@ -232,6 +223,8 @@ after_bundle do
     end
   end
 
+  empty_directory File.join("app", "views", "application")
+
   # Remove require_tree .
 
   gsub_file "app/assets/stylesheets/application.css", " *= require_tree .\n", ""
@@ -247,6 +240,7 @@ after_bundle do
   file "config/initializers/fetch_store_patch.rb", render_file("fetch_store_patch.rb")
   file "config/initializers/attribute-methods-patch.rb", render_file("attribute-methods-patch.rb")
 
+  file ".codio", render_file(".codio")
 
   inside "config" do
     inside "initializers" do
@@ -284,6 +278,10 @@ after_bundle do
       package-lock.json
     EOF
   end
+
+  gsub_file ".gitignore",
+  "/db/*.sqlite3\n/db/*.sqlite3-journal",
+  "# /db/*.sqlite3\n# /db/*.sqlite3-journal"
 
   unless skip_active_admin
     # Set up Active Admin


### PR DESCRIPTION
As we migrate to Codio, some changes need to made to the template. 

This branch makes the following changes:

- Update setup for Codio and remove `diff2html` installation
- Update `rails dev:prime` to have more verbose implementation
- Use new stable version of web_git
- Un-ignore sqlite db files
- Add `.codio` file #57 
- Remove `dev_toolbar` #61 
- Set `config.debug.assets = false` in `development.rb` #56
- Disable required belongs_to association by default
- Use latest version of hashdiff gem
- Add `views/application` #59 