### PR TITLE
Whitelist process on port 3000

### DIFF
--- a/files/server
+++ b/files/server
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-kill -9 $(lsof -i tcp:8080 -t) >/dev/null 2>/dev/null
-rails server -b $IP -p $PORT
+kill -9 $(lsof -i tcp:3000 -t) >/dev/null 2>/dev/null
+rails server -b 0.0.0.0

--- a/files/whitelist
+++ b/files/whitelist
@@ -20,7 +20,7 @@ begin
   File.open(path, 'w') {|f| f.write whitelisted_ips.to_yaml }
 
   puts "Stopping Rails server. Please restart it."
-  `kill -9 $(lsof -i tcp:8080 -t) >/dev/null 2>/dev/null`
+  `kill -9 $(lsof -i tcp:3000 -t) >/dev/null 2>/dev/null`
 rescue
   puts "That was not a valid IP address. Try copying the command again."
   puts "Be careful not to cut part of it off, or repeat part of it."


### PR DESCRIPTION
Codio runs the server on port 3000. Previously Cloud 9 ran the server on port 8080. Now `bin/whitelist` needs to kill the process running on port 3000.