### PR TITLE
Move admin_user model elsewhere

### DIFF
--- a/template.rb
+++ b/template.rb
@@ -121,6 +121,9 @@ after_bundle do
             g.javascripts     false
             g.helper          false
           end
+          # Load AdminUser model
+          config.autoload_paths += %W(\#{config.root}/vendor/app/models)
+
           config.action_controller.default_protect_from_forgery = false
           config.active_record.belongs_to_required_by_default = false
           RUBY
@@ -291,6 +294,10 @@ after_bundle do
 
     rails_command "db:migrate"
     rails_command "db:seed"
+
+    empty_directory "vendor/app"
+    empty_directory "vendor/app/models"
+    run "mv app/models/admin_user.rb vendor/app/models"
 
     inside "config" do
       inside "initializers" do


### PR DESCRIPTION
firstdraft/appdev#135

This branch moves the `admin_user` model to the `vendors/app/models/` folder as well as loading that file in the `application.rb`.