### PR TITLE
Remove 'concerns/' folder from controllers and models

### DIFF
--- a/template.rb
+++ b/template.rb
@@ -347,6 +347,10 @@ after_bundle do
     end
   end
 
+  # Remove concerns folders
+  remove_dir "app/controllers/concerns"
+  remove_dir "app/models/concerns"
+
   prepend_file "spec/spec_helper.rb" do
     <<-'RUBY'.gsub(/^      /, "")
       require "factory_bot_rails"


### PR DESCRIPTION
#67 The changes made will now remove the `concerns/` folder from both the `controllers/` folder as well as the `models/` folder.

There didn't seem to be a [Thor method ](https://rdoc.info/github/erikhuda/thor/master/Thor/Actions#run-instance_method) for removing folders specifically so I just used a Bash command.

