### PR TITLE
Resolve #72 - Fix the gsub of db/seeds.rb

### DIFF
--- a/template.rb
+++ b/template.rb
@@ -289,8 +289,16 @@ after_bundle do
     generate "active_admin:install"
 
     gsub_file "db/seeds.rb",
-      /AdminUser.create!(email: 'admin@example.com', password: 'password', password_confirmation: 'password')/,
-      "AdminUser.create(email: \"admin@example.com\", password: \"password\", password_confirmation: \"password\")"
+      /AdminUser.create!.*/,
+      <<~RUBY
+        if Rails.env.development?
+          AdminUser.create({
+            :email => "admin@example.com",
+            :password => "password",
+            :password_confirmation => "password",
+          })
+        end
+      RUBY
 
     rails_command "db:migrate"
     rails_command "db:seed"


### PR DESCRIPTION
#72 - Fixes the gsub of `db/seeds.rb`

For some reason, `rails g active_admin:install` now adds a conditional to the `AdminUser.create!` method call in `db.seeds.rb` which was breaking the Regex that `template.rb` was using to gsub the file. I've updated the Regex to be more accommodating.