### PR TITLE
Update to rails 6

### DIFF
--- a/fd
+++ b/fd
@@ -1,7 +1,7 @@
 --skip-action-cable
---skip-coffee
 --skip-system-test
 --skip-test
 --skip-turbolinks
---skip-yarn
+--skip-action-mailbox
+--skip-action-text
 --template=https://raw.githubusercontent.com/firstdraft/appdev_template/master/template.rb

--- a/files/README.md
+++ b/files/README.md
@@ -1,6 +1,5 @@
 ## Standard Workflow
 
- 1. From [your Cloud9 repositories list](https://c9.io/account/repos), set up a workspace [as usual](https://guides.firstdraft.com/starting-on-a-project-in-cloud9).
  1. Set up the project: `bin/setup`
  1. Start the web server by clicking "Run Project".
  1. Navigate to your live application preview.

--- a/template.rb
+++ b/template.rb
@@ -34,8 +34,8 @@ def render_file(filename)
 end
 
 skip_active_admin = false
-# skip_devise = false
-skip_devise = yes?("Skip Devise?")
+skip_devise = false
+# skip_devise = yes?("Skip Devise?")
 
 # Remove default sqlite3 version
 # =================
@@ -44,17 +44,15 @@ gsub_file "Gemfile", /^gem\s+["']sqlite3["'].*$/,''
 # Add standard gems
 # =================
 
-gem "hashdiff", [">= 1.0.0.beta1", "< 2.0.0"]
-
 gem_group :development, :test do
   gem "awesome_print"
   gem "console_ip_whitelist", github: "firstdraft/console_ip_whitelist"
   gem "dotenv-rails"
   gem "grade_runner", github: "firstdraft/grade_runner"
   gem "pry-rails"
-  gem "sqlite3", "~> 1.3.6"
+  gem "sqlite3", "~> 1.4.1"
   gem "table_print"
-  gem "web_git"
+  gem "web_git", github: "firstdraft/web_git"
 end
 
 gem_group :development do
@@ -164,6 +162,7 @@ after_bundle do
     inside "environments" do
       insert_into_file "development.rb", after: "Rails.application.configure do\n" do
         <<-RB.gsub(/^      /, "")
+          config.hosts.clear
           path = Rails.root.join("whitelist.yml")
           default_whitelist_path = Rails.root.join("default_whitelist.yml")
           whitelisted_ips = []
@@ -208,16 +207,6 @@ after_bundle do
             <!-- Expand the number of characters we can use in the document beyond basic ASCII 🎉 -->
             <meta charset="utf-8">
 
-            <!-- Connect Font Awesome CSS -->
-            <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.1.0/css/all.css">
-
-            <!-- Connect Bootstrap CSS -->
-            <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.1/css/bootstrap.min.css">
-
-            <!-- Connect Bootstrap JavaScript and its dependencies -->
-            <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js"></script>
-            <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.1/js/bootstrap.bundle.min.js"></script>
-
             <!-- Make it responsive to small screens -->
             <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
           HTML
@@ -231,14 +220,12 @@ after_bundle do
   # Remove require_tree .
 
   gsub_file "app/assets/stylesheets/application.css", " *= require_tree .\n", ""
-  gsub_file "app/assets/javascripts/application.js", "//= require_tree .\n", ""
 
   # Better backtraces
   file "config/initializers/active_record_relation_patch.rb", render_file("active_record_relation_patch.rb")
 
   file "config/initializers/nicer_errors.rb", render_file("nicer_errors.rb")
   file "config/initializers/delegation_monkey_patch.rb", render_file("delegation_monkey_patch.rb")
-
 
   file "config/initializers/fetch_store_patch.rb", render_file("fetch_store_patch.rb")
   file "config/initializers/attribute-methods-patch.rb", render_file("attribute-methods-patch.rb")
@@ -260,7 +247,7 @@ after_bundle do
   end
 
   initializer 'open_uri.rb', <<-CODE
-    require "open-uri"
+    require("open-uri")
 
   CODE
 
@@ -310,7 +297,6 @@ after_bundle do
 
     empty_directory "vendor/app"
     empty_directory "vendor/app/models"
-    run "mv app/models/admin_user.rb vendor/app/models"
 
     inside "config" do
       inside "initializers" do
@@ -351,6 +337,8 @@ after_bundle do
   # Set up rspec and capybara
 
   generate "rspec:install"
+
+  run "mv app/models/admin_user.rb vendor/app/models"
 
   remove_file ".rspec"
   file ".rspec", render_file(".rspec")
@@ -432,6 +420,7 @@ after_bundle do
   git add: "-A"
   git commit: "-m \"rails new\""
 end
+
 
 # TODO List
 # =========


### PR DESCRIPTION
Resolve #83 

Update the template to configure Rails 6 apps in the decided way.

- adds flags
  ```
  --skip-action-mailbox
  --skip-action-text
  ```
- adds `config.hosts.clear` to `development.rb` [read more](https://www.fngtps.com/2019/rails6-blocked-host/)
- slightly update `READ.me`
- removes bootstrap links from `application.html.erb`
- uses `web_git` gem from [github](https://github.com/firstdraft/teachersmanual/blob/master/updating-old-projects-checklist.md#gems).

Clone, checkout jw-update-to-rails-6 branch, 
```bash
rails new rails-6-test-app --rc=<path to fd> -m <path to template.rb> 
```

The new app should be able to navigate to:
- `/` and see "Yay, you're on Rails
- `/git`
- `/admin` and login with `admin@example.com` and `password`

#### Note:
There are a couple temporary changes I've made so that review is as easy as possible.
In `template.rb`
```ruby
# ENV = :prod
ENV = :dev
```
This change is because we're in development and the changes aren't in `master` yet.

In `fd`
The removal of
```
--template=https://raw.githubusercontent.com/firstdraft/appdev_template/master/template.rb
```
For similar reasons. I will add them back after approval.