### PR TITLE
Lock activeadmin version

### DIFF
--- a/template.rb
+++ b/template.rb
@@ -82,7 +82,7 @@ gsub_file "Gemfile",
   "gem 'bcrypt'"
 
 gem "devise" unless skip_devise
-gem "activeadmin" unless skip_active_admin
+gem "activeadmin", "2.2.0"
 # gem "bootstrap-sass"
 # gem "jquery-rails"
 # gem "font-awesome-sass", "~> 4.7.0"


### PR DESCRIPTION
Fixes firstdraft/draft_generators/issues/68 until we determine a better course of action.

Currently newly generated apps cannot run draft_generators because of a recent `activeadmin` change. This branch makes the following change:
- Lock `activeadmin` at version `2.2.0`.

I suspect we'll come to a better consensus later about how to update draft_generators but for now this functions as a temporary fix, since assignments still need to be generated. 