### PR TITLE
Gitpod Updates

### DIFF
--- a/files/.gitpod.yml
+++ b/files/.gitpod.yml
@@ -1,4 +1,4 @@
-image: jelaniwoods/appdev-base
+image: jelaniwoods/appdev-ruby2_6_5
 
 tasks:
   - init: bin/setup

--- a/files/server
+++ b/files/server
@@ -1,4 +1,10 @@
 #!/bin/bash
 
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+parentdir="$(dirname "$DIR")"
+pid="$parentdir/tmp/pids/server.pid"
+if [ -f $pid ]; then
+  rm $pid
+fi
 fuser -k -n tcp 3000
 rails server -b 0.0.0.0

--- a/template.rb
+++ b/template.rb
@@ -46,7 +46,7 @@ gsub_file "Gemfile", /^gem\s+["']sqlite3["'].*$/,''
 
 gem_group :development, :test do
   gem "awesome_print"
-#   gem "console_ip_whitelist", github: "firstdraft/console_ip_whitelist"
+  # gem "console_ip_whitelist", github: "firstdraft/console_ip_whitelist"
   gem "dotenv-rails"
   gem "grade_runner", github: "firstdraft/grade_runner"
   gem "pry-rails"
@@ -177,6 +177,9 @@ after_bundle do
 
           config.web_console.permissions = whitelisted_ips
           config.web_console.whiny_requests = false
+
+          BetterErrors::Middleware.allow_ip! '10.138.0.0/16'
+
         RB
       end
     end


### PR DESCRIPTION
This branch addresses some issues we were having using gitpod.
Occasionally, stale pid files were created preventing students from simply running `bin/server` and we had to `rm` the file for them.

Gitpod does a weird thing with changing ip addresses that prevented us from using the console_ip_whitelist gem. There also doesn't appear to be a way to whitelist _all_ ips for BetterErrors.

To address these issues, I've made the following changes:

- Make `bin/server` remvove any stale pid files if they exist
- Whitelist All Gitpod ip addresses, `BetterErrors::Middleware.allow_ip! '10.138.0.0/16'`

I tested in [this project](https://github.com/jmw686-appdev/msm-api), which you can fork or just open in Gitpod to test.

Fixes firstdraft/appdev#190
Fixes firstdraft/appdev#197
