### PR TITLE
Make Gitpod choose the Ruby version

### DIFF
--- a/files/.gitpod.yml
+++ b/files/.gitpod.yml
@@ -1,7 +1,7 @@
 image: jelaniwoods/appdev-base
 
 tasks:
-  - init: bin/setup
+  - init: source ~/.rvm/scripts/rvm && cd .. && cd - && bin/setup
 ports:
   - port: 3000
     onOpen: open-preview


### PR DESCRIPTION
To prevent `bin/setup` from failing because the user is using the incorrect Ruby version, we can let `rvm` choose what ruby to use.

I didn't think this was necessary since the Docker image _already_ `source`s `rvm`. You can even arrow up in a new Gitpod workspace and see the `source` command in the Bash history... Regardless, now when the project is initialized, we source the `rvm` and then exit and re-enter the project folder so the correct Ruby version is selected. Finally `bin/setup` will run.