### PR TITLE
Refine string representation fo `ActiveRecord::Relation`

### DIFF
--- a/files/active_record_relation_patch.rb
+++ b/files/active_record_relation_patch.rb
@@ -3,7 +3,7 @@ module ActiveRecord
     def to_s
       row_count = count
       
-      "Array containing #{row_count} #{model} #{"record".pluralize(row_count)}"
+      "#{self.class} (array with #{row_count} #{model} #{"instance".pluralize(row_count)} inside)"
     end
   end
 end


### PR DESCRIPTION
Right now, something like `Photo.all` will display something like

```
=> Array containing 323 Photo records
```

This patch proposes slightly different copy,

```
=> Photo::ActiveRecord_Relation (array with 323 Photo instances inside)
```

I suggest we do this along with splitting up the ActiveRecord Chapter into multiple chapters:

 - Creating and modifying database tables
 - Creating a single row (An `ActiveRecord` instance)
 - Updating a single row
 - Deleting a single row
 - Retrieving a set of rows (An `ActiveRecord::Relation`)

And then we keep using the term "relation" heavily, rather than "array" or "collection", and demonstrate doing `.class` often after `.all` or `.where` or `.order`.

Thoughts?