### PR TITLE
Update Heroku pre-configuration

### DIFF
--- a/files/puma.rb
+++ b/files/puma.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+# Puma can serve each request in a thread from an internal thread pool.
+# The `threads` method setting takes two numbers: a minimum and maximum.
+# Any libraries that use thread pools should be configured to match
+# the maximum value specified for Puma. Default is set to 5 threads for minimum
+# and maximum; this matches the default thread size of Active Record.
+#
+threads_count = ENV.fetch("RAILS_MAX_THREADS") { 5 }
+threads threads_count, threads_count
+
+# Specifies the `port` that Puma will listen on to receive requests; default is 3000.
+#
+port        ENV.fetch("PORT") { 3000 }
+
+# Specifies the `environment` that Puma will run in.
+#
+environment ENV.fetch("RAILS_ENV") { "development" }
+
+# Specifies the number of `workers` to boot in clustered mode.
+# Workers are forked web server processes. If using threads and workers together
+# the concurrency of the application would be max `threads` * `workers`.
+# Workers do not work on JRuby or Windows (both of which do not support
+# processes).
+#
+workers ENV.fetch("WEB_CONCURRENCY") { 2 }
+
+# Use the `preload_app!` method when specifying a `workers` number.
+# This directive tells Puma to first boot the application and load code
+# before forking the application. This takes advantage of Copy On Write
+# process behavior so workers use less memory.
+#
+preload_app!
+
+# Allow puma to be restarted by `rails restart` command.
+plugin :tmp_restart
+
+on_worker_boot do
+  # Worker specific setup for Rails 4.1+
+  # See: https://devcenter.heroku.com/articles/deploying-rails-applications-with-the-puma-web-server#on-worker-boot
+  ActiveRecord::Base.establish_connection
+end

--- a/files/rack_timeout.rb
+++ b/files/rack_timeout.rb
@@ -1,0 +1,1 @@
+Rails.application.config.middleware.insert_before Rack::Runtime, Rack::Timeout, service_timeout: 30

--- a/template.rb
+++ b/template.rb
@@ -43,6 +43,7 @@ gsub_file "Gemfile", /^gem\s+["']sqlite3["'].*$/,''
 
 # Add standard gems
 # =================
+gem "rack-timeout", require: "rack/timeout/base"
 
 gem_group :development, :test do
   gem "awesome_print"
@@ -232,6 +233,8 @@ after_bundle do
 
   file "config/initializers/fetch_store_patch.rb", render_file("fetch_store_patch.rb")
   file "config/initializers/attribute-methods-patch.rb", render_file("attribute-methods-patch.rb")
+  remove_file "config/puma.rb"
+  file "config/puma.rb", render_file("puma.rb")
 
   file ".gitpod.yml", render_file(".gitpod.yml")
   file ".pryrc", render_file(".pryrc")


### PR DESCRIPTION
Fixes #97 
In request to keep the Heroku setup up to date after upgrading to Rails 6,  this pr makes updates to `puma.rb` and some other configuration using Heroku's suggestions.
