### PR TITLE
Skip all the things

### DIFF
--- a/fd
+++ b/fd
@@ -1,7 +1,8 @@
 --skip-action-cable
---skip-system-test
---skip-test
---skip-turbolinks
 --skip-action-mailbox
---skip-action-text
+--skip-action-mailer
+--skip-active-storage
+--skip-javascript
+--skip-test
+
 --template=https://raw.githubusercontent.com/firstdraft/appdev_template/master/template.rb


### PR DESCRIPTION
I am proposing some changes to the default railsrc file (which I think we should rename from `fd` to something like `adp` for "appdev project" — we should eventually make a different `fd` rc file and app template for regular, firstdraft projects).

I think it would be nice if we can remove some clutter from early projects; folders for things that we'll never use like channels and webpacker.

I also stopped skipping system tests, because I believe the recommended path from RSpec is to use them:

https://medium.com/table-xi/a-quick-guide-to-rails-system-tests-in-rspec-b6e9e8a8b5f6