### PR TITLE
Add setting to enable emmet in ERB files

### DIFF
--- a/files/settings.json
+++ b/files/settings.json
@@ -1,4 +1,7 @@
 {
   "editor.autoSave": "on",
   "editor.tabSize": 2,
+  "emmet.includeLanguages": {
+    "erb": "html"
+},
 }


### PR DESCRIPTION
In the ongoing effort to improve the experience of writing in ERB files, this setting will enable emmet snippets.

Current issue: This apparently, changes the comment character to `//` though, which is weird and I don't understand why. I intend to find a solution to make commenting better too.