### PR TITLE
Add Dockerfile for Gitpod

### DIFF
--- a/files/.gitpod.Dockerfile
+++ b/files/.gitpod.Dockerfile
@@ -1,0 +1,19 @@
+FROM gitpod/workspace-full:latest
+
+USER root
+
+RUN apt-get update
+
+WORKDIR /myapp
+
+USER gitpod
+
+WORKDIR /myapp
+ENV PATH /usr/local/rvm/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+RUN /bin/bash -l -c "rvm requirements"
+RUN /bin/bash -l -c "rvm install 2.6.5"
+COPY Gemfile /myapp/Gemfile
+COPY Gemfile.lock /myapp/Gemfile.lock
+RUN /bin/bash -l -c "rvm use --default 2.6.5"
+
+RUN /bin/bash -l -c "bundle install"

--- a/files/.gitpod.yml
+++ b/files/.gitpod.yml
@@ -1,7 +1,8 @@
-image: jelaniwoods/appdev-ruby2_6_5
+image:
+  file: .gitpod.Dockerfile
 
 tasks:
-  - init: bin/setup
+  - init: yarn install --check-files && bin/setup
 ports:
   - port: 3000
     onOpen: open-preview

--- a/template.rb
+++ b/template.rb
@@ -240,6 +240,7 @@ after_bundle do
   file "config/puma.rb", render_file("puma.rb")
 
   file ".gitpod.yml", render_file(".gitpod.yml")
+  file ".gitpod.Dockerfile", render_file(".gitpod.Dockerfile")
   file ".pryrc", render_file(".pryrc")
   file "Procfile", render_file("Procfile")
 


### PR DESCRIPTION
By using a Dockerfile in each project, we can pre-bundle the gems for each project. We also aren't installing multiple versions of gems in the image that was causing some issues with firstdraft/appdev#216.

The requested changes are:
- Add a Dockerfile to the root folder of each project.
- In the `gitpod.yml` use the Dockerfile instead of a specific image.

The one hangup:
- I can't access the `yarn` command when building the image. This is strange because `yarn` should definitely be installed in the base image, since it's not like we had installed it before. 


You can open this branch of photogram-signin in Gitpod to see the changes.
[Open in Gitpod](https://gitpod.io#https://github.com/appdev-projects/photogram-signin/tree/jw-test-dockerization)