### PR TITLE
Remove Webpacker, ActionMailer, and the like

### DIFF
--- a/fd
+++ b/fd
@@ -4,4 +4,8 @@
 --skip-turbolinks
 --skip-action-mailbox
 --skip-action-text
+--skip-action-mailer
+--skip-javascript
+--skip-webpack-install
+
 --template=https://raw.githubusercontent.com/firstdraft/appdev_template/master/template.rb

--- a/files/setup
+++ b/files/setup
@@ -16,7 +16,7 @@ chdir APP_ROOT do
   puts "== Installing dependencies =="
   system! "bundle install"
 
-  system! "yarn install --check-files"
+  # system! "yarn install --check-files"
   # Install JavaScript dependencies if using Yarn
   # system("bin/yarn")
 

--- a/template.rb
+++ b/template.rb
@@ -40,10 +40,16 @@ skip_devise = false
 # Remove default sqlite3 version
 # =================
 gsub_file "Gemfile", /^gem\s+["']sqlite3["'].*$/,''
+gsub_file "Gemfile", /^gem\s+["']sass-rails["'].*$/,""
 
 # Add standard gems
 # =================
 gem "rack-timeout", require: "rack/timeout/base"
+gem 'sprockets', '< 4'
+gem 'sassc-rails'
+# Javascript for Gitpod
+gem 'execjs'
+gem 'therubyracer', :platforms => :ruby
 
 gem_group :development, :test do
   gem "awesome_print"
@@ -136,11 +142,11 @@ after_bundle do
       end
   end
 
-  # Configure mailer in development
+  # # Configure mailer in development
 
-  environment \
-    "config.action_mailer.default_url_options = { host: \"localhost\", port: 3000 }",
-    env: "development"
+  # environment \
+  #   "config.action_mailer.default_url_options = { host: \"localhost\", port: 3000 }",
+  #   env: "development"
 
   # Better default favicon
 
@@ -227,6 +233,7 @@ after_bundle do
   # Remove require_tree .
 
   gsub_file "app/assets/stylesheets/application.css", " *= require_tree .\n", ""
+  gsub_file "app/views/layouts/application.html.erb", "javascript_pack_tag", "javascript_include_tag"
 
   # Better backtraces
   file "config/initializers/active_record_relation_patch.rb", render_file("active_record_relation_patch.rb")
@@ -251,6 +258,35 @@ after_bundle do
           Rails.backtrace_cleaner.add_silencer { |line| line =~ /lib|gems/ }
 
         RUBY
+      end
+    end
+  end
+
+  inside "app" do
+    inside "assets" do
+      inside "config" do
+        append_file "manifest.js" do
+          <<-RUBY.gsub(/^          /, "")
+            //= link_directory ../javascripts .js
+
+          RUBY
+        end
+      end
+    end
+  end
+
+  create_file "app/assets/javascripts/application.js"
+  
+  inside "app" do
+    inside "assets" do
+      inside "javascripts" do
+        append_file "application.js" do
+          <<-RUBY.gsub(/^          /, "")
+          /*
+          *= require_self
+          */
+          RUBY
+        end
       end
     end
   end


### PR DESCRIPTION
Webpacker and Rails 6 has a lot of extra stuff that increases load time, that students won't need for the basic projects. 

This changes in this branch:
- Adds the following flags:
```
--skip-action-mailer
--skip-javascript
--skip-webpack-install
```
- Remove `sass-rails`, replaced with `sassc-rails`
- Add `sprockets` less than version 4
- Add `gem 'execjs'` and `therubyracer` for Gitpod
-  Remove `action_mailer` from `development.rb`
- Substitute `javascript_pack_tag` with `javascript_include_tag` in `application.html.erb`
- Add `app/assets/javascripts/application.js`

Clone, checkout jw-remove-webpacker branch, 
```bash
rails new no-webpack --rc=<path to fd> -m <path to template.rb> 
```

The new app should be able to navigate to:
- `/` and see "Yay, you're on Rails
- `/git`
- `/admin` and login with `admin@example.com` and `password`

#### Note:
There are a couple temporary changes I've made so that review is as easy as possible.
In `template.rb`
```ruby
# ENV = :prod
ENV = :dev
```
This change is because we're in development and the changes aren't in `master` yet.

In `fd`
The removal of
```
--template=https://raw.githubusercontent.com/firstdraft/appdev_template/master/template.rb
```
For similar reasons. I will add them back after approval.


##### Other Note
`fd` is just an arbitraly named file that is used to store all the flags we run with `rails new`.

You can run `rails` to see the info:
```shell
[--rc=RC]   # Path to file containing extra configuration options for rails command
```