### PR TITLE
Update JSON rspec formatter to not show NAN% when project is worth no points

### DIFF
--- a/files/json_output_formatter.rb
+++ b/files/json_output_formatter.rb
@@ -24,12 +24,20 @@ class JsonOutputFormatter < RSpec::Core::Formatters::JsonFormatter
       earned_points: earned_points,
       score: (earned_points.to_f / total_points).round(4)
     }
+    score = (@output_hash[:summary][:score] * 100).round(2)
+    
+    if score.nan?
+      score = "This project is not graded."
+    else
+      score = score.to_s + "%"
+    end
+    
     
     @output_hash[:summary_line] = [
-      "#{summary.example_count} tests",
+      "#{summary.example_count} #{summary.example_count == 1 ? "test" : "tests"}",
       "#{summary.failure_count} failures",
       "#{earned_points}/#{total_points} points",
-      "#{(@output_hash[:summary][:score] * 100).round(2)}%",
+      score,
     ].join(", ")
   end
 


### PR DESCRIPTION
Resolves firstdraft/grades#404

After countless piazza questions about NaN% :
- https://piazza.com/class/k52jbhk0blz6la?cid=86
- https://piazza.com/class/k52jbhk0blz6la?cid=165
- https://piazza.com/class/k52jbhk0blz6la?cid=170
- https://piazza.com/class/k52jbhk0blz6la?cid=197

Since `rails grade` is just running 
```bash
rspec --order default --format JsonOutputFormatter
```
If you run that `rspec` command in a project with no points (like base-rails) it produces something like:

```bash
{"version":"3.9.0","examples":[
{"description":"has no tests","full_description":"This project has no tests",
"hint":null,"status":"passed",
"points":null,"file_path":"./spec/features/dummy_spec.rb",
"line_number":4,"run_time":0.00346}],
"summary":
{"duration":0.007012,"example_count":1,"failure_count":0,
"pending_count":0,"total_points":0,"earned_points":0,"score":null},
"summary_line":"1 tests, 0 failures, 0/0 points, NaN%"}%
```

This change updates 

```shell
{"version":"3.9.0","examples":[
{"description":"has no tests","full_description":"This project has no tests",
"hint":null,"status":"passed",
"points":null,"file_path":"./spec/features/dummy_spec.rb",
"line_number":4,"run_time":0.001988}],
"summary":
{"duration":0.003999,"example_count":1,"failure_count":0,
"pending_count":0,"total_points":0,"earned_points":0,"score":null},
"summary_line":"1 tests, 0 failures, 0/0 points, This project is not graded."}%
```

<img width="909" alt="Screen Shot 2020-03-05 at 8 01 17 PM" src="https://user-images.githubusercontent.com/17581658/76043191-610a2800-5f1c-11ea-8882-9ba4b39c8659.png">
