### PR TITLE
Use Oj to parse JSON in JsonOutputFormatter

### DIFF
--- a/files/json_output_formatter.rb
+++ b/files/json_output_formatter.rb
@@ -5,15 +5,15 @@ class JsonOutputFormatter < RSpec::Core::Formatters::JsonFormatter
 
   def dump_summary(summary)
     total_points = summary.
-    examples.
-    map { |example| example.metadata[:points].to_i }.
-    sum
-
+      examples.
+      map { |example| example.metadata[:points].to_i }.
+      sum
+      
     earned_points = summary.
-    examples.
-    select { |example| example.execution_result.status == :passed }.
-    map { |example| example.metadata[:points].to_i }.
-    sum
+      examples.
+      select { |example| example.execution_result.status == :passed }.
+      map { |example| example.metadata[:points].to_i }.
+      sum
 
     @output_hash[:summary] = {
       duration: summary.duration,
@@ -41,6 +41,10 @@ class JsonOutputFormatter < RSpec::Core::Formatters::JsonFormatter
     ].join(", ")
   end
 
+  def close(_notification)
+    output.write  Oj.dump @output_hash
+  end
+  
   private
 
   def format_example(example)


### PR DESCRIPTION
This is Part 1 of the changes that will fix the intended error. The [`grade_runner`](https://github.com/firstdraft/grade_runner/pull/35) is responsible for the other part.

There have been a few strange issues where a utf-8 character, like an emoji, will break the JSON formatting of the rspec output. It's inconsistent, which is bad, but seems to consistently fail on Gitpod, which is all that matters. Create a workspace from [this repo](https://github.com/demostudent10-appdev/rps-html/tree/oops_i_didnt_mean_to_delete_public) and run `rspec --format j` will fail. Since the Ruby JSON conversion fails with 

```bash
`encode': "\xF0" from ASCII-8BIT to UTF-8 (Encoding::UndefinedConversionError)
```

You can reproduce this error by creating a Gitpod workspace from [this repo](https://github.com/demostudent10-appdev/rps-html/tree/1dc60f8655818e53a089b1a1eaa22b21886e4227) and running `rails grade` or `rspec --format j` or `rspec --format JsonOutputFormatter`.


This appears to be an issue in the JSON parser of Ruby itself, which is why our custom JSON formatter also fails. I don't have time to look into it more deeply, but am interested in learning of the true cause. 

In particular, [the default `rspec` JSON formatter](https://github.com/rspec/rspec-core/blob/50c12ab2f98a0ff8d9ef018682a8d523b465abef/lib/rspec/core/formatters/json_formatter.rb#L55) has a `close` method that does 
```ruby
def close(_notification)
  output.write(@output_hash.to_json)
end
```

and that `to_json` will cause the encoding error.

Many attempts to change or force encoding did not seem to work, [but simply using `oj` 🍊🧃did](https://stackoverflow.com/a/18920869/10481804). By substituting `to_json` with `Oj.dump`, UTF characters are parsed without issue. This seems okay to do, since grades already uses `oj` for stuff.

The proposed change

```ruby
def close(_notification)
  output.write  Oj.dump @output_hash
end
```
should prevent any UTF-8 conversion errors triggered from running `rspec --format JsonOutputFormatter`.

Any conversion errors are triggered from `grade_runner` and are resolved here https://github.com/firstdraft/grade_runner/pull/35.