### PR TITLE
Create Dockerfile with current Ruby version.

### DIFF
--- a/files/Dockerfile
+++ b/files/Dockerfile
@@ -1,0 +1,44 @@
+FROM gitpod/workspace-full:latest
+
+USER root
+
+RUN sudo apt-get update
+
+RUN sudo apt-get install -y unzip xvfb libxi6 libgconf-2-4
+RUN sudo apt-get install default-jdk -y
+
+COPY .irbrc ~/.irbrc
+WORKDIR /base-rails
+
+RUN sudo curl -sS -o - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add
+RUN sudo echo "deb [arch=amd64]  http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list
+RUN sudo apt-get -y update
+
+RUN sudo apt-get -y install google-chrome-stable
+
+RUN wget https://chromedriver.storage.googleapis.com/2.41/chromedriver_linux64.zip
+RUN unzip chromedriver_linux64.zip
+
+RUN sudo mv chromedriver /usr/bin/chromedriver
+RUN sudo chown root:root /usr/bin/chromedriver
+RUN sudo chmod +x /usr/bin/chromedriver
+
+RUN wget https://selenium-release.storage.googleapis.com/3.13/selenium-server-standalone-3.13.0.jar
+RUN wget http://www.java2s.com/Code/JarDownload/testng/testng-6.8.7.jar.zip
+RUN unzip testng-6.8.7.jar.zip
+
+USER gitpod
+WORKDIR /base-rails
+ENV PATH /usr/local/rvm/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+RUN /bin/bash -l -c "rvm requirements"
+RUN /bin/bash -l -c "rvm install 2.6.5"
+RUN /bin/bash -l -c "curl https://cli-assets.heroku.com/install.sh | sh"
+
+COPY Gemfile /base-rails/Gemfile
+COPY Gemfile.lock /base-rails/Gemfile.lock
+
+RUN /bin/bash -l -c "rvm use --default 2.6.5"
+
+RUN /bin/bash -l -c "gem install bundler"
+RUN /bin/bash -l -c "bundle install"
+RUN /bin/bash -l -c "gem uninstall -i /home/gitpod/.rvm/rubies/ruby-2.6.5/lib/ruby/gems/2.6.0 minitest"

--- a/template.rb
+++ b/template.rb
@@ -489,6 +489,13 @@ after_bundle do
 
   file "default_whitelist.yml",
     render_file("default_whitelist.yml")
+  
+  # Add Dockerfile
+  file "Dockerfile", render_file("Dockerfile")
+
+  ruby_version = open(".ruby-version").read
+  ruby_version = ruby_version.gsub("ruby-", "").strip
+  gsub_file("Dockerfile", "2.6.5", ruby_version)
 
   rails_command "db:migrate"
 


### PR DESCRIPTION
Part of #114 

Adds a `Dockerfile` that has the current version of Ruby the project was generated with.

While entirely possible, I don't think the template should build the docker image and push to Docker hub. It could take too much time also we might add more project specific gems. If that is something we want to do, I think there should be a command or task for it (maybe in the `appdev_support` gem).

I'm also unsure of whether it makes sense to default the `gitpod.yml` to use this `Dockerfile` or not. There is a change of syntax from

```yml
image: jelaniwoods/appdev2020-base
```

to

```yml
file: Dockerfile
```
Maybe that's something for the task that deploys?