### PR TITLE
Force Un-gitignore of vendor/

### DIFF
--- a/template.rb
+++ b/template.rb
@@ -318,6 +318,7 @@ after_bundle do
       node_modules
       package-lock.json
       core.chrome*
+      !vendor/
     EOF
   end
 


### PR DESCRIPTION
Fixes #129 

Don't gitignore the `vendor/` folder because we put `admin_user.rb` in there.