### PR TITLE
Remove rails_12factor gem

### DIFF
--- a/template.rb
+++ b/template.rb
@@ -82,7 +82,6 @@ end
 
 gem_group :production do
   gem "pg"
-  gem "rails_12factor"
 end
 
 gsub_file "Gemfile",


### PR DESCRIPTION
Resolves #118 

The `DEPRECATION WARNING: Including LoggerSilence` was really tricky to nail down, but it turns out it's from a dependency of `rails_12factor`— [`rails_stout_logging`](https://github.com/heroku/rails_stdout_logging/blob/b21ed3a29748d2fe62ef1f4fe6bda34294a42dc9/lib/rails_stdout_logging/rails.rb#L3)

[It's not recommended ](https://github.com/heroku/rails_12factor#new-rails-5-apps)to use `rails_12factor` gem in app starting from 5+, so I think removing the gem is an acceptable solution.

An alternative configuration for Rails 6 apps has been proposed but it doesn't seem necessary if we don't need the gem for something else.