### PR TITLE
Disable solargraph popups.

### DIFF
--- a/files/settings.json
+++ b/files/settings.json
@@ -3,5 +3,11 @@
   "editor.tabSize": 2,
   "emmet.includeLanguages": {
     "erb": "html"
-},
+  },
+  "solargraph.checkGemVersion": false,
+  "solargraph.hover": false,
+  "solargraph.diagnostics": false,
+  "solargraph.completion": false,
+  "solargraph.autoformat": false,
+  "solargraph.formatting": false
 }


### PR DESCRIPTION
Resolves https://github.com/firstdraft/appdev/issues/234

While I still am unsure of how to prevent the Solargraph extension from being added (Gitpod adds it by default to a configured workspace), these settings should prevent the outdated gem version popups and as long as the gem is installed the big `"Solargraph server couldn't start"` error shouldn't happen.

