### PR TITLE
Add Theia tasks and keyboard shortcut.

### DIFF
--- a/files/keymaps.json
+++ b/files/keymaps.json
@@ -1,0 +1,6 @@
+[
+  {
+      "command": "task:run",
+      "keybinding": "shift+alt+r"
+  }
+]

--- a/files/tasks.json
+++ b/files/tasks.json
@@ -1,0 +1,13 @@
+{
+	// See https://go.microsoft.com/fwlink/?LinkId=733558
+	// for the documentation about the tasks.json format
+	"version": "2.0.0",
+	"tasks": [
+    {
+      "label": "server",
+      "type": "shell",
+      "command": "bin/server",
+      "problemMatcher": []
+    }
+  ]
+}

--- a/template.rb
+++ b/template.rb
@@ -351,6 +351,8 @@ after_bundle do
 
     empty_directory ".theia"
     file ".theia/settings.json", render_file("settings.json")
+    file ".theia/tasks.json", render_file("tasks.json")
+    file ".theia/keymaps.json", render_file("keymaps.json")
 
     inside "config" do
       inside "initializers" do


### PR DESCRIPTION
Will most likely resolve https://github.com/firstdraft/appdev/issues/130

It seems you can define Tasks, that the editor will run for you if you tell it the task name.

![run-task](https://user-images.githubusercontent.com/17581658/81423041-7ae10a80-9119-11ea-8a62-0d63a586aebd.gif)

This change adds the `bin/server` command as a Task called `server` as well as a Keyboard shortcut to open the Run Task bar, `shift+alt+r`.

Here's a snapshot of a workspace I tested it in [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io#snapshot/0f2d536d-31f2-4c70-9e04-8a47254ea48f)
