### PR TITLE
Fix .pryrc printing

### DIFF
--- a/files/.pryrc
+++ b/files/.pryrc
@@ -3,6 +3,6 @@ Pry.config.print = proc do |output, value, _pry_|
   when ActiveRecord::Relation
     output.puts "=> #{value.to_s}"
   else
-    Pry::DEFAULT_PRINT.call(output, value, _pry_)
+    Pry::ColorPrinter.default(output, value, _pry_)
   end
 end


### PR DESCRIPTION
Resolves #137 

For some reason `Pry::DEFAULT_PRINT` is no longer a (public?) constant on Pry. I'm not sure when this change happened, since it still mentions it in the [docs](https://github.com/pry/pry/wiki/Customization-and-configuration#the-print-object) as the default value 🤔.

```rb
Pry.constants.include? :DEFAULT_PRINTER # => false
```

Regardless, `Pry::ColorPrinter.default` performs as expected so I believe this solves the issue.

<img width="637" alt="Screen Shot 2020-05-08 at 4 50 28 PM" src="https://user-images.githubusercontent.com/17581658/81452978-05dbf800-914e-11ea-8411-6c2735e284f2.png">
