### PR TITLE
Downgrade 'better_errors' gem.

### DIFF
--- a/template.rb
+++ b/template.rb
@@ -64,7 +64,7 @@ end
 
 gem_group :development do
   gem "annotate"
-  gem "better_errors"
+  gem "better_errors", "2.6"
   gem "binding_of_caller"
   gem "draft_generators", github: "firstdraft/draft_generators", branch: "winter-2020"
   gem "letter_opener"


### PR DESCRIPTION
Fixes https://github.com/firstdraft/appdev/issues/275

Use version `2.6` so errors in the View template show up. This was verified in https://github.com/appdev-projects/a-quick-puzzle/commit/99b9baa8da617f345216d6f75768163228a9a006#