### PR TITLE
Make consistent with minimal

### DIFF
--- a/fd
+++ b/fd
@@ -8,5 +8,4 @@
 --skip-action-mailer
 --skip-javascript
 --skip-webpack-install
-
 --template=https://raw.githubusercontent.com/firstdraft/appdev_template/master/template.rb

--- a/files/Dockerfile
+++ b/files/Dockerfile
@@ -31,17 +31,17 @@ USER gitpod
 WORKDIR /base-rails
 ENV PATH /usr/local/rvm/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 RUN /bin/bash -l -c "rvm requirements"
-RUN /bin/bash -l -c "rvm install 2.6.5"
+RUN /bin/bash -l -c "rvm install 2.6.6"
 RUN /bin/bash -l -c "curl https://cli-assets.heroku.com/install.sh | sh"
 
 COPY Gemfile /base-rails/Gemfile
 COPY Gemfile.lock /base-rails/Gemfile.lock
 
-RUN /bin/bash -l -c "rvm use --default 2.6.5"
+RUN /bin/bash -l -c "rvm use --default 2.6.6"
 
 RUN /bin/bash -l -c "gem install bundler"
 RUN /bin/bash -l -c "bundle install"
-RUN /bin/bash -l -c "gem uninstall -i /home/gitpod/.rvm/rubies/ruby-2.6.5/lib/ruby/gems/2.6.0 minitest"
+RUN /bin/bash -l -c "gem uninstall -i /home/gitpod/.rvm/rubies/ruby-2.6.6/lib/ruby/gems/2.6.0 minitest"
 
 RUN echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc
 RUN echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc

--- a/files/dev.rake
+++ b/files/dev.rake
@@ -1,5 +1,2 @@
-namespace(:dev) do
-  desc "Hydrate the database with some dummy data to look at so that developing is easier"
-  task({ :prime => :environment}) do
-  end
+task({ :dummy_data => :environment}) do
 end

--- a/files/puma.rb
+++ b/files/puma.rb
@@ -6,7 +6,7 @@
 # the maximum value specified for Puma. Default is set to 5 threads for minimum
 # and maximum; this matches the default thread size of Active Record.
 #
-threads_count = ENV.fetch("RAILS_MAX_THREADS") { 5 }
+threads_count = ENV.fetch("RAILS_MAX_THREADS") { 1 }
 threads threads_count, threads_count
 
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
@@ -23,7 +23,7 @@ environment ENV.fetch("RAILS_ENV") { "development" }
 # Workers do not work on JRuby or Windows (both of which do not support
 # processes).
 #
-workers ENV.fetch("WEB_CONCURRENCY") { 2 }
+workers ENV.fetch("WEB_CONCURRENCY") { 1 }
 
 # Use the `preload_app!` method when specifying a `workers` number.
 # This directive tells Puma to first boot the application and load code

--- a/template.rb
+++ b/template.rb
@@ -67,8 +67,8 @@ gem_group :development do
   gem "better_errors", "2.6"
   gem "binding_of_caller"
   gem "draft_generators", github: "firstdraft/draft_generators", branch: "winter-2020"
-  gem "letter_opener"
-  gem "meta_request"
+  # gem "letter_opener"
+  # gem "meta_request"
   gem "rails_db", "2.3.1"
 end
 
@@ -97,9 +97,12 @@ gem "devise" unless skip_devise
 
 # Use WEBrick
 
-# gsub_file "Gemfile",
-#   /gem 'puma'/,
-#   "# gem 'puma'"
+gsub_file "Gemfile",
+  /gem 'jbuilder'.*$/,
+  ""
+gsub_file "Gemfile",
+  "# Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder",
+  ""
 
 # Remove tzinfo-data warning  
 `bundle lock --add-platform x86-mingw32 x86-mswin32 x64-mingw32 java`
@@ -134,9 +137,7 @@ after_bundle do
             g.javascripts     false
             g.helper          false
           end
-          # Load AdminUser model
-          config.autoload_paths += %W(\#{config.root}/vendor/app/models)
-
+          
           config.action_controller.default_protect_from_forgery = false
           config.active_record.belongs_to_required_by_default = false
           RUBY
@@ -144,9 +145,8 @@ after_bundle do
   end
 
   gsub_file "config/application.rb",
-    "# require \"action_mailer/railtie\"",
-    "require \"action_mailer/railtie\""
-  # # Configure mailer in development
+          /require "active_job\/railtie"$/,
+          "# require \"active_job\/railtie\""
 
   # environment \
   #   "config.action_mailer.default_url_options = { host: \"localhost\", port: 3000 }",
@@ -232,7 +232,7 @@ after_bundle do
     end
   end
 
-  empty_directory File.join("app", "views", "application")
+  # empty_directory File.join("app", "views", "application")
   
   empty_directory File.join("config", "initializers", "active_record")
   empty_directory File.join("config", "initializers", "active_record", "relation")
@@ -276,7 +276,7 @@ after_bundle do
       inside "config" do
         append_file "manifest.js" do
           <<-RUBY.gsub(/^          /, "")
-            //= link_directory ../javascripts .js
+          //= link_directory ../javascripts .js
 
           RUBY
         end
@@ -443,6 +443,7 @@ after_bundle do
   # Remove concerns folders
   remove_dir "app/controllers/concerns"
   remove_dir "app/models/concerns"
+  remove_dir "app/jobs"
 
   prepend_file "spec/spec_helper.rb" do
     <<-'RUBY'.gsub(/^      /, "")


### PR DESCRIPTION
The new `--minimal` flag will remove

- action_cable
- action_mailbox
- action_mailer
- action_text
- active_job
- active_storage
- bootsnap
- jbuilder
- spring
- system_tests
- turbolinks
- webpack

The proposed changes:
- manually remove `active_job` folders and files (since there isn't a flag yet)
- manually remove `jbuilder` (there isn't a flag yet)
- `dev:prime` => `dummy_data`
- remove `letter_opener` and `meta_request` gems
- updates Docker image
- configure puma to be single threaded

Why make puma single threaded?

The "Session Expired" `better_errors` can be resolved if we stick to a single threaded server in development. See https://github.com/BetterErrors/better_errors/issues/292#issuecomment-554461349
