### PR TITLE
Update Dockerfile to improve build time and size

### DIFF
--- a/files/Dockerfile
+++ b/files/Dockerfile
@@ -1,49 +1,67 @@
-FROM gitpod/workspace-full:latest
+FROM ubuntu:focal-20200916
 
-USER root
+RUN apt-get update
 
-RUN sudo apt-get update
+RUN apt-get install -y unzip xvfb libxi6 libgconf-2-4 curl wget gnupg2 default-jdk sudo
 
-RUN sudo apt-get install -y unzip xvfb libxi6 libgconf-2-4
-RUN sudo apt-get install default-jdk -y
-
-# COPY .irbrc ~/.irbrc
-WORKDIR /base-rails
-
-RUN sudo curl -sS -o - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add
-RUN sudo echo "deb [arch=amd64]  http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list
+RUN curl -sS -o - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add
+RUN echo "deb [arch=amd64]  http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list
 RUN sudo apt-get -y update
 
-RUN sudo apt-get -y install google-chrome-stable
+RUN sudo apt-get -y install google-chrome-stable git
 
 RUN wget https://chromedriver.storage.googleapis.com/2.41/chromedriver_linux64.zip
 RUN unzip chromedriver_linux64.zip
 
-RUN sudo mv chromedriver /usr/bin/chromedriver
-RUN sudo chown root:root /usr/bin/chromedriver
-RUN sudo chmod +x /usr/bin/chromedriver
+RUN mv chromedriver /usr/bin/chromedriver
+RUN chown root:root /usr/bin/chromedriver
+RUN chmod +x /usr/bin/chromedriver
 
 RUN wget https://selenium-release.storage.googleapis.com/3.13/selenium-server-standalone-3.13.0.jar
 RUN wget http://www.java2s.com/Code/JarDownload/testng/testng-6.8.7.jar.zip
 RUN unzip testng-6.8.7.jar.zip
 
+RUN useradd -l -u 33333 -G sudo -md /home/gitpod -s /bin/bash -p gitpod gitpod \
+    # passwordless sudo for users in the 'sudo' group
+    && sed -i.bkp -e 's/%sudo\s\+ALL=(ALL\(:ALL\)\?)\s\+ALL/%sudo ALL=NOPASSWD:ALL/g' /etc/sudoers
+ENV HOME=/home/gitpod
+WORKDIR $HOME
+# custom Bash prompt
+RUN { echo && echo "PS1='\[\e]0;\u \w\a\]\[\033[01;32m\]\u\[\033[00m\] \[\033[01;34m\]\w\[\033[00m\] \\\$ '" ; } >> .bashrc
+
+### Gitpod user (2) ###
 USER gitpod
+# use sudo so that user does not get sudo usage info on (the first) login
+RUN sudo echo "Running 'sudo' for Gitpod: success" 
+
 WORKDIR /base-rails
+
+RUN  gpg2 --keyserver hkp://pool.sks-keyservers.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
+RUN curl -L https://get.rvm.io | bash -s stable
 ENV PATH /usr/local/rvm/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 RUN /bin/bash -l -c "rvm requirements"
 RUN /bin/bash -l -c "rvm install 2.6.6"
-RUN /bin/bash -l -c "curl https://cli-assets.heroku.com/install.sh | sh"
+
+RUN sudo apt install -y postgresql postgresql-contrib libpq-dev psmisc lsof
+RUN sudo wget https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6-1/wkhtmltox_0.12.6-1.focal_amd64.deb && \
+    echo y | sudo apt install ./wkhtmltox_0.12.6-1.focal_amd64.deb python3-pip build-essential libssl-dev libffi-dev python3-dev
+
+RUN /bin/bash -l -c "rvm use --default 2.6.6"
+RUN /bin/bash -l -c "gem install htmlbeautifier"
+RUN /bin/bash -l -c "gem install rufo"
+
+RUN sudo apt-get update && \
+    yes Y | sudo apt install dirmngr gnupg apt-transport-https ca-certificates software-properties-common && \
+    sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E298A3A825C0D65DFD57CBB651716619E084DAB9 && \
+    sudo add-apt-repository 'deb https://cloud.r-project.org/bin/linux/ubuntu focal-cran40/' && \
+    yes Y | sudo apt install r-base pkg-config graphviz-dev imagemagick && \
+    sudo apt-get install -y graphviz
 
 COPY Gemfile /base-rails/Gemfile
 COPY Gemfile.lock /base-rails/Gemfile.lock
 
-RUN /bin/bash -l -c "rvm use --default 2.6.6"
-
 RUN /bin/bash -l -c "gem install bundler"
 RUN /bin/bash -l -c "bundle install"
-RUN /bin/bash -l -c "gem uninstall -i /home/gitpod/.rvm/rubies/ruby-2.6.6/lib/ruby/gems/2.6.0 minitest"
 
-RUN echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc
-RUN echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc
-RUN echo 'if command -v pyenv 1>/dev/null 2>&1; then\n  eval "$(pyenv init -)"\nfi' >> ~/.bashrc
-RUN /bin/bash -l -c "gem install htmlbeautifier"
+RUN /bin/bash -l -c "curl https://cli-assets.heroku.com/install.sh | sh"
+


### PR DESCRIPTION
The current base image, ` gitpod/workspace-full:latest`, that we've been using is very large— around `7.19GB` _before_ any appdev stuff is installed. Afterwards the images end up being 8-9GB!

This limits the number of images you can store on your computer, increases build time, and increases the time it takes to push to Docker Hub.

The proposed changes start from an `ubuntu` base image that starts at `72.9MB`. Once all the necessary programs are installed, the image size is around `2.21GB` (`2.73GB` with R, Python3, `wkhtmltopdf`, `graphviz`, and `imagemagick` installed)— which is much more manageable!

Starting from `ubuntu`, we need to install
- curl
- wget
- gnupg2
- default-jdk
- sudo
- git
- rvm
- postgresql
- postgresql-contrib
- libpq-dev
- psmisc
- lsof
- r-base and dependencies
- wkhtmltopdf and dependencies
- python3 dependencies

We also need to make a non-root user (`gitpod`) and configure it to work with `sudo`

https://github.com/firstdraft/appdev_template/blob/9922296e84cfe4b1c63244a92ce1e205c6d41b11/files/Dockerfile#L24-L28

Everything else is the same or were hacks to get around configuration in the `gitpod/workspace-full` image that are no longer necessary.

The only layers that need to re-build between projects are

https://github.com/firstdraft/appdev_template/blob/6bb2fa0bb4ab7e2c22fefe260b7a8d14eb085721/files/Dockerfile#L58-L64

so the bottleneck is basically `sassc` and to a lesser degree `nokogiri`.

`bundler` is always installed so we don't have to worry about having the wrong version of bundler installed.

Heroku CLI is always installed so it's up to date and students don't see warning messages about it being out of date.

This was tested with this repo: https://github.com/appdev-projects/photogram-final/tree/jw-fall20-updates