### PR TITLE
Auto connect to development db

### DIFF
--- a/template.rb
+++ b/template.rb
@@ -181,6 +181,9 @@ after_bundle do
 
           BetterErrors::Middleware.allow_ip! '10.138.0.0/16'
 
+          console do
+            ActiveRecord::Base.connection
+          end
         RB
       end
     end


### PR DESCRIPTION
Resolves https://github.com/firstdraft/appdev_template/issues/158

This is no fun
```irb
[1] pry(main)> Event
=> Event (call 'Event.connection' to establish a connection)
```

Add 
```ruby
    console do
      ActiveRecord::Base.connection
    end
```

to `development.rb`

[source](https://stackoverflow.com/a/33722673/10481804)