### PR TITLE
Show ruby error message in test summary line

### DIFF
--- a/files/json_output_formatter.rb
+++ b/files/json_output_formatter.rb
@@ -32,6 +32,7 @@ class JsonOutputFormatter < RSpec::Core::Formatters::JsonFormatter
     
     if summary.errors_outside_of_examples_count.positive?
       result = "An error occurred while running tests"
+      result += @output_hash[:messages].first
     else
       result = result.to_s + "%"
     end


### PR DESCRIPTION
Resolves https://github.com/firstdraft/grade_runner/issues/44

To run locally, you can clone any appdev project and replace the `json_output_formatter.rb` with these updates and then run

```bash
bundle exec rspec --require ./spec/support/json_output_formatter.rb --format JsonOutputFormatter --no-color
```

You could alternatively run `rails grade` with any active token and view the results in the grades UI.